### PR TITLE
remove /f flag from kill command and call it twice so edge exits cleanly

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,13 +13,20 @@ function EdgeBrowser (baseBrowserDecorator, logger) {
   var log = logger.create('launcher')
 
   function killEdgeProcess (cb) {
-    exec('taskkill /t /f /im MicrosoftEdge.exe', function (err) {
+    var killCommand = 'taskkill /t /im MicrosoftEdge.exe'
+    exec(killCommand, function (err) {
       if (err) {
         log.error('Killing Edge process failed. ' + err)
       } else {
-        log.debug('Killed Edge process')
+        exec(killCommand, function (err) {
+          if (err) {
+            log.error('Killing Edge process failed. ' + err)
+          } else {
+            log.debug('Killed Edge process')
+          }
+          cb()
+        })
       }
-      cb()
     })
   }
 

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -115,7 +115,7 @@ describe('launcher', function () {
 
     it('should call taskkill', function (done) {
       onProcessExit()
-      expect(childProcessCmd).to.equal('taskkill /t /f /im MicrosoftEdge.exe')
+      expect(childProcessCmd).to.equal('taskkill /t /im MicrosoftEdge.exe')
       done()
     })
   })


### PR DESCRIPTION
As I commented in [#29](https://github.com/nickmccurdy/karma-edge-launcher/pull/29) killing Edge with /f flag doesn't close it correctly and it opens all the previously opened tabs on start, in an automated setup this would make Edge to open lots of tabs with no user to close them.

I removed the /f flag and called the taskkill command twice (testing this shows that edge closes with the second call)